### PR TITLE
Convert story central to use the JSON and Transients APIs

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -206,36 +206,33 @@
       <div id="noresults" style="visibility:hidden"><h3>No results found</h3></div>
       <div id="grid-isotope" class="grid js-isotope isotope">
       <div id="grid-sizer" class="grid-sizer"></div>
-           <?php
-           $args = array(
-            'posts_per_page'  => 25,
-            'orderby'         => 'post_date',
-            'post_type'       => 'story',
-            'post_status'     => 'publish'
-          );
-          $posts = get_posts($args);
-          foreach( $posts as $post ) : setup_postdata($post);
+      <?php
+
+        $url = 'http://cms.local/api/story_central_posts/get_all_story_central_posts/';
+        $json_data = file_get_contents($url);
+        $data = (array)json_decode($json_data);
+        $posts = $data['posts'];
+
+        foreach( $posts as $post ) : setup_postdata($post);
           $tags = "";
-          $slugs = wp_get_post_tags($post->ID, array('fields' => 'slugs'));
+          $slugs = $post->tags;
           foreach($slugs as $slug) : $tags = $tags . $slug . " "; endforeach;
-          $pillars = wp_get_post_terms($post->ID, 'pillar', array('fields' => 'slugs'));
+          $pillars = $post->pillars;
           foreach($pillars as $pillar) : $tags = $tags . $pillar . " "; endforeach; ?>
 
-               <div class="boundless-tile grid-item element-item <?php echo $tags; ?>" >
-                   <div class='boundless-image' style='background-image:url("<?php echo get_story_featured_image_url($post->ID, false, array(350,350)) ?>");' ></div>
-                      <div class="boundless-text">
-                          <h3 class="searchtag"><a href='<?php the_permalink(); ?>'><?php the_title(); ?></a></h3>
-                          <p class="searchtag"><?php echo get_abstract_text($post->ID); ?></p>
-                          <div class="searchbody" style="display:none"><?php echo the_content(); ?></div>
-                          <a class="more" href='<?php the_permalink(); ?>'>More</a>
-                   </div>
-               </div>
+          <div class="boundless-tile grid-item element-item <?php echo $tags; ?>" >
+              <div class='boundless-image' style='background-image:url("<?php echo $post->image; ?>");' ></div>
+                  <div class="boundless-text">
+                      <h3 class="searchtag"><a href='<?php echo $post->link ?>'><?php echo $post->title; ?></a></h3>
+                      <p class="searchtag"><?php echo $post->excerpt; ?></p>
+                      <div class="searchbody" style="display:none"><?php echo $post->content; ?></div>
+                      <a class="more" href='<?php echo $post->link; ?>'>More</a>
+              </div>
+          </div>
 
-           <?php endforeach; ?>
+      <?php endforeach; ?>
       </div>
       </div>
-
-      <div class="load-more-stories"><a class="uw-btn" href="ajax-all-stories">Load more</a></div>
 
   </div>
   </div> <!-- main -->

--- a/functions.php
+++ b/functions.php
@@ -18,3 +18,23 @@ class UW_Story_Central
 }
 
 new UW_Story_Central;
+
+function add_story_central_posts_controller($controllers) {
+    $controllers[] = 'story_central_posts';
+    return $controllers;
+}
+add_filter('json_api_controllers', 'add_story_central_posts_controller');
+
+function set_story_central_posts_controller_path() {
+    return dirname(__FILE__) . "/inc/story-central-json.php";
+}
+add_filter('json_api_story_central_posts_controller_path', 'set_story_central_posts_controller_path');
+
+add_action( 'save_post', 'bust_story_central_transient');
+function bust_story_central_transient() {
+	global $post;
+    if (get_post_type($post) == "story") {
+        delete_transient('get_all_story_central_posts');
+        wp_schedule_single_event( time(), 'story_updated' );
+	}
+}

--- a/inc/story-central-json.php
+++ b/inc/story-central-json.php
@@ -1,0 +1,76 @@
+<?php
+/*
+Controller name: Story Central
+Controller description: Necessary json for the story central requests
+*/
+
+class json_api_story_central_posts_controller
+{
+  public function get_all_story_central_posts() {
+    global $json_api;
+
+    $transient_name = 'get_all_story_central_posts';
+
+    $data_timeout = get_option('_transient_timeout_' . $transient_name);
+    $transient = ($data_timeout < time()) ? false : true ;
+
+    if ($transient == true) {
+        $story_central_posts = get_transient($transient_name);
+    } else {
+      $posts = $json_api->introspector->get_posts(array(
+        'posts_per_page'  => -1,
+        'orderby'         => 'post_date',
+        'post_type'       => 'story',
+        'post_status'     => 'publish'
+      ));
+
+      foreach ($posts as $post) {
+        $story_central = new stdClass();
+
+        $custom_fields = $post->custom_fields;
+        $excerpt = $custom_fields->abstract;
+
+        $img_src = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ) , array(350,350) );
+        $img_url = ( has_post_thumbnail( $post->ID ) ) ? reset( $img_src ) : '';
+
+        $tag_slugs = array();
+        $pillar_slugs = array();
+
+        foreach ($post->tags as $tag) {
+          array_push($tag_slugs, html_entity_decode($tag->slug));
+        }
+
+        foreach ($post->taxonomy_pillar as $pillar) {
+            array_push($pillar_slugs, html_entity_decode($pillar->slug));
+        }
+
+        $story_central->{title}             = html_entity_decode($post->title);
+        $story_central->{link}              = $post->url;
+        $story_central->{tags}              = $tag_slugs;
+        $story_central->{pillars}           = $pillar_slugs;
+        $story_central->{image}             = $img_url;
+        $story_central->{excerpt}           = $excerpt[0];
+        $story_central->{content}           = $post->content;
+
+        $story_central_posts[]                   = $story_central;
+      }
+      set_transient($transient_name, $story_central_posts, 48 * HOUR_IN_SECONDS);
+    }
+
+    return $this->posts_object_result($story_central_posts , null);
+  }
+
+  public function error() {
+    global $json_api;
+    $json_api->error("That method does not exist");
+  }
+
+  protected function posts_object_result($posts) {
+    return array(
+      'count' => count($posts),
+      'posts' => $posts
+    );
+  }
+}
+
+?>


### PR DESCRIPTION
Added `inc/story-central-json.php` to create a transient in the Wordpress database and deliver all stories in JSON format. 

Edited `front-page.php` to call the json controller.

Edited `functions.php` to register the json controller and bust the transient when a new story is saved.